### PR TITLE
쿠폰 사용 시점 변경 및 결과 생성 로직 리팩토링

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+src/main/resources/static/fonts/*
+src/main/resources/static/certification.pdf

--- a/src/main/java/site/brainbrain/iqtest/controller/PaymentController.java
+++ b/src/main/java/site/brainbrain/iqtest/controller/PaymentController.java
@@ -11,19 +11,26 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import site.brainbrain.iqtest.controller.dto.PaymentConfirmResponse;
+import site.brainbrain.iqtest.service.CouponService;
 import site.brainbrain.iqtest.service.payment.PaymentService;
 
 @RestController
 public class PaymentController {
 
     private final PaymentService paymentService;
+    private final CouponService couponService;
 
-    public PaymentController(@Qualifier("nicePaymentService") final PaymentService paymentService) {
+    public PaymentController(@Qualifier("nicePaymentService") final PaymentService paymentService,
+                             final CouponService couponService) {
         this.paymentService = paymentService;
+        this.couponService = couponService;
     }
 
     @PostMapping("/payments/confirm")
-    public ResponseEntity<PaymentConfirmResponse> confirm(@RequestParam final Map<String, String> params) {
+    public ResponseEntity<PaymentConfirmResponse> confirm(@RequestParam(name = "coupon", required = false) final String coupon,
+                                                          @RequestParam final Map<String, String> params) {
+        couponService.tryConsumeIfPresent(coupon);
+
         final PaymentConfirmResponse response = paymentService.pay(params);
         return ResponseEntity.status(HttpStatus.FOUND)
                 .location(URI.create("https://brainbrain.site/")) // 임시 리다이렉트 경로

--- a/src/main/java/site/brainbrain/iqtest/controller/ResultController.java
+++ b/src/main/java/site/brainbrain/iqtest/controller/ResultController.java
@@ -11,9 +11,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import site.brainbrain.iqtest.controller.dto.CreateResultRequest;
 import site.brainbrain.iqtest.domain.PurchaseOption;
-import site.brainbrain.iqtest.exception.CouponException;
 import site.brainbrain.iqtest.service.CertificateService;
-import site.brainbrain.iqtest.service.CouponService;
 import site.brainbrain.iqtest.service.EmailService;
 import site.brainbrain.iqtest.service.ScoreService;
 import site.brainbrain.iqtest.service.payment.PaymentService;
@@ -25,27 +23,19 @@ public class ResultController {
     private final CertificateService certificateService;
     private final ScoreService scoreService;
     private final EmailService emailService;
-    private final CouponService couponService;
 
     public ResultController(@Qualifier("nicePaymentService") final PaymentService paymentService,
                             final CertificateService certificateService,
                             final ScoreService scoreService,
-                            final EmailService emailService,
-                            final CouponService couponService) {
+                            final EmailService emailService) {
         this.paymentService = paymentService;
         this.certificateService = certificateService;
         this.scoreService = scoreService;
         this.emailService = emailService;
-        this.couponService = couponService;
     }
 
     @PostMapping("/results")
     public void create(@RequestBody final CreateResultRequest request) {
-        if (couponService.isUnavailableCoupon(request.couponCode())) {
-            paymentService.cancel(request.orderId());
-            throw new CouponException("이미 사용된 쿠폰이거나 유효하지 않은 쿠폰입니다.");
-        }
-
         final PurchaseOption purchaseOption = paymentService.getPurchaseOptionByOrderId(request.orderId());
         final List<Integer> answers = request.answers();
 

--- a/src/main/java/site/brainbrain/iqtest/controller/ResultController.java
+++ b/src/main/java/site/brainbrain/iqtest/controller/ResultController.java
@@ -1,8 +1,5 @@
 package site.brainbrain.iqtest.controller;
 
-import java.io.ByteArrayOutputStream;
-import java.util.List;
-
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -11,45 +8,27 @@ import org.springframework.web.bind.annotation.RestController;
 
 import site.brainbrain.iqtest.controller.dto.CreateResultRequest;
 import site.brainbrain.iqtest.domain.PurchaseOption;
-import site.brainbrain.iqtest.service.CertificateService;
-import site.brainbrain.iqtest.service.EmailService;
-import site.brainbrain.iqtest.service.ScoreService;
+import site.brainbrain.iqtest.domain.result.ResultStrategy;
+import site.brainbrain.iqtest.domain.result.ResultStrategyFactory;
 import site.brainbrain.iqtest.service.payment.PaymentService;
 
 @RestController
 public class ResultController {
 
     private final PaymentService paymentService;
-    private final CertificateService certificateService;
-    private final ScoreService scoreService;
-    private final EmailService emailService;
+    private final ResultStrategyFactory resultStrategyFactory;
 
     public ResultController(@Qualifier("nicePaymentService") final PaymentService paymentService,
-                            final CertificateService certificateService,
-                            final ScoreService scoreService,
-                            final EmailService emailService) {
+                            final ResultStrategyFactory resultStrategyFactory) {
         this.paymentService = paymentService;
-        this.certificateService = certificateService;
-        this.scoreService = scoreService;
-        this.emailService = emailService;
+        this.resultStrategyFactory = resultStrategyFactory;
     }
 
     @PostMapping("/results")
     public void create(@RequestBody final CreateResultRequest request) {
         final PurchaseOption purchaseOption = paymentService.getPurchaseOptionByOrderId(request.orderId());
-        final List<Integer> answers = request.answers();
-
-        final var scoreResult = scoreService.calculate(answers);
-        final String name = request.userInfoRequest().name();
-
-        if (containsCertificate(purchaseOption)) {
-            final ByteArrayOutputStream certificate = certificateService.generate(name, scoreResult);
-            emailService.send(request.userInfoRequest().email(), name, certificate);
-        }
-    }
-
-    private boolean containsCertificate(final PurchaseOption purchaseOption) {
-        return purchaseOption == PurchaseOption.STANDARD || purchaseOption == PurchaseOption.PREMIUM;
+        final ResultStrategy strategy = resultStrategyFactory.getStrategy(purchaseOption);
+        strategy.createResult(request);
     }
 
     @GetMapping("/check")

--- a/src/main/java/site/brainbrain/iqtest/controller/dto/CreateResultRequest.java
+++ b/src/main/java/site/brainbrain/iqtest/controller/dto/CreateResultRequest.java
@@ -2,8 +2,7 @@ package site.brainbrain.iqtest.controller.dto;
 
 import java.util.List;
 
-public record CreateResultRequest(String couponCode,
-                                  String orderId,
+public record CreateResultRequest(String orderId,
                                   UserInfoRequest userInfoRequest,
                                   List<Integer> answers) {
 }

--- a/src/main/java/site/brainbrain/iqtest/domain/result/BasicResultStrategy.java
+++ b/src/main/java/site/brainbrain/iqtest/domain/result/BasicResultStrategy.java
@@ -1,0 +1,36 @@
+package site.brainbrain.iqtest.domain.result;
+
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import site.brainbrain.iqtest.controller.dto.CreateResultRequest;
+import site.brainbrain.iqtest.domain.PurchaseOption;
+import site.brainbrain.iqtest.domain.ScoreResult;
+import site.brainbrain.iqtest.service.EmailService;
+import site.brainbrain.iqtest.service.ScoreService;
+
+@Component
+@RequiredArgsConstructor
+public class BasicResultStrategy implements ResultStrategy {
+
+    private final ScoreService scoreService;
+    private final EmailService emailService;
+
+    @Override
+    public PurchaseOption getPurchaseOption() {
+        return PurchaseOption.BASIC;
+    }
+
+    @Override
+    public void createResult(final CreateResultRequest request) {
+        final String email = request.userInfoRequest().email();
+        final String name = request.userInfoRequest().name();
+
+        final List<Integer> answers = request.answers();
+        final ScoreResult scoreResult = scoreService.calculate(answers);
+
+        emailService.sendOnlyScore(email, name, scoreResult);
+    }
+}

--- a/src/main/java/site/brainbrain/iqtest/domain/result/PremiumResultStrategy.java
+++ b/src/main/java/site/brainbrain/iqtest/domain/result/PremiumResultStrategy.java
@@ -1,0 +1,41 @@
+package site.brainbrain.iqtest.domain.result;
+
+import java.io.ByteArrayOutputStream;
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import site.brainbrain.iqtest.controller.dto.CreateResultRequest;
+import site.brainbrain.iqtest.domain.PurchaseOption;
+import site.brainbrain.iqtest.domain.ScoreResult;
+import site.brainbrain.iqtest.service.CertificateService;
+import site.brainbrain.iqtest.service.EmailService;
+import site.brainbrain.iqtest.service.ScoreService;
+
+@Component
+@RequiredArgsConstructor
+public class PremiumResultStrategy implements ResultStrategy {
+
+    private final ScoreService scoreService;
+    private final EmailService emailService;
+    private final CertificateService certificateService;
+
+    @Override
+    public PurchaseOption getPurchaseOption() {
+        return PurchaseOption.PREMIUM;
+    }
+
+    @Override
+    public void createResult(final CreateResultRequest request) {
+        final String email = request.userInfoRequest().email();
+        final String name = request.userInfoRequest().name();
+
+        final List<Integer> answers = request.answers();
+        final ScoreResult scoreResult = scoreService.calculate(answers);
+
+        final ByteArrayOutputStream certificate = certificateService.generate(name, scoreResult);
+        emailService.sendCertificate(email, name, certificate);
+        //todo: 인증서 배송 로직 추가
+    }
+}

--- a/src/main/java/site/brainbrain/iqtest/domain/result/ResultStrategy.java
+++ b/src/main/java/site/brainbrain/iqtest/domain/result/ResultStrategy.java
@@ -1,0 +1,11 @@
+package site.brainbrain.iqtest.domain.result;
+
+import site.brainbrain.iqtest.controller.dto.CreateResultRequest;
+import site.brainbrain.iqtest.domain.PurchaseOption;
+
+public interface ResultStrategy {
+
+    PurchaseOption getPurchaseOption();
+
+    void createResult(final CreateResultRequest request);
+}

--- a/src/main/java/site/brainbrain/iqtest/domain/result/ResultStrategyFactory.java
+++ b/src/main/java/site/brainbrain/iqtest/domain/result/ResultStrategyFactory.java
@@ -1,0 +1,28 @@
+package site.brainbrain.iqtest.domain.result;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Component;
+
+import site.brainbrain.iqtest.domain.PurchaseOption;
+import site.brainbrain.iqtest.exception.PurchaseOptionException;
+
+@Component
+public class ResultStrategyFactory {
+
+    private final Map<PurchaseOption, ResultStrategy> resultStrategies;
+
+    public ResultStrategyFactory(final List<ResultStrategy> strategies) {
+        this.resultStrategies = strategies.stream()
+                .collect(Collectors.toMap(ResultStrategy::getPurchaseOption, Function.identity()));
+    }
+
+    public ResultStrategy getStrategy(final PurchaseOption purchaseOption) {
+        return Optional.ofNullable(resultStrategies.get(purchaseOption))
+                .orElseThrow(() -> new PurchaseOptionException("구매 옵션과 일치하는 결과를 생성할 수 없습니다."));
+    }
+}

--- a/src/main/java/site/brainbrain/iqtest/domain/result/StandardResultStrategy.java
+++ b/src/main/java/site/brainbrain/iqtest/domain/result/StandardResultStrategy.java
@@ -1,0 +1,40 @@
+package site.brainbrain.iqtest.domain.result;
+
+import java.io.ByteArrayOutputStream;
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import site.brainbrain.iqtest.controller.dto.CreateResultRequest;
+import site.brainbrain.iqtest.domain.PurchaseOption;
+import site.brainbrain.iqtest.domain.ScoreResult;
+import site.brainbrain.iqtest.service.CertificateService;
+import site.brainbrain.iqtest.service.EmailService;
+import site.brainbrain.iqtest.service.ScoreService;
+
+@Component
+@RequiredArgsConstructor
+public class StandardResultStrategy implements ResultStrategy {
+
+    private final ScoreService scoreService;
+    private final EmailService emailService;
+    private final CertificateService certificateService;
+
+    @Override
+    public PurchaseOption getPurchaseOption() {
+        return PurchaseOption.STANDARD;
+    }
+
+    @Override
+    public void createResult(final CreateResultRequest request) {
+        final String email = request.userInfoRequest().email();
+        final String name = request.userInfoRequest().name();
+
+        final List<Integer> answers = request.answers();
+        final ScoreResult scoreResult = scoreService.calculate(answers);
+
+        final ByteArrayOutputStream certificate = certificateService.generate(name, scoreResult);
+        emailService.sendCertificate(email, name, certificate);
+    }
+}

--- a/src/main/java/site/brainbrain/iqtest/service/CouponService.java
+++ b/src/main/java/site/brainbrain/iqtest/service/CouponService.java
@@ -8,6 +8,7 @@ import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 import site.brainbrain.iqtest.controller.dto.CouponResponse;
 import site.brainbrain.iqtest.domain.Coupon;
+import site.brainbrain.iqtest.exception.CouponException;
 import site.brainbrain.iqtest.repository.CouponRepository;
 
 @RequiredArgsConstructor
@@ -23,8 +24,13 @@ public class CouponService {
     }
 
     @Transactional
-    public boolean isUnavailableCoupon(final String code) {
-        final int updatedRow = couponRepository.markAsUsed(code, LocalDateTime.now());
-        return updatedRow == 0;
+    public void tryConsumeIfPresent(final String coupon) {
+        if (coupon == null) {
+            return;
+        }
+        final int updatedRow = couponRepository.markAsUsed(coupon, LocalDateTime.now());
+        if (updatedRow == 0) {
+            throw new CouponException("이미 사용된 쿠폰이거나 유효하지 않은 쿠폰입니다.");
+        }
     }
 }

--- a/src/main/java/site/brainbrain/iqtest/service/EmailService.java
+++ b/src/main/java/site/brainbrain/iqtest/service/EmailService.java
@@ -11,6 +11,7 @@ import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
+import site.brainbrain.iqtest.domain.ScoreResult;
 import site.brainbrain.iqtest.exception.BrainBrainMailException;
 import site.brainbrain.iqtest.util.MailAttachmentConverter;
 
@@ -24,7 +25,22 @@ public class EmailService {
 
     private final JavaMailSender mailSender;
 
-    public void send(final String email, final String name, final ByteArrayOutputStream certificate) {
+    public void sendOnlyScore(final String email, final String name, final ScoreResult scoreResult) {
+        try {
+            final MimeMessage message = mailSender.createMimeMessage();
+            final MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
+
+            helper.setTo(email);
+            helper.setSubject(MAIL_TITLE);
+            helper.setText(name + "님의 IQ 점수는 : " + scoreResult.cattell()); //todo: 점수만 전송할 때 텍스트만? 혹은 이미지로?
+
+            mailSender.send(message);
+        } catch (final Exception e) {
+            throw new BrainBrainMailException("이메일 전송에 실패했습니다.");
+        }
+    }
+
+    public void sendCertificate(final String email, final String name, final ByteArrayOutputStream certificate) {
         try {
             final MimeMessage message = mailSender.createMimeMessage();
             final MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");

--- a/src/test/java/site/brainbrain/iqtest/service/CouponServiceTest.java
+++ b/src/test/java/site/brainbrain/iqtest/service/CouponServiceTest.java
@@ -84,10 +84,11 @@ class CouponServiceTest {
         final AtomicInteger failCount = new AtomicInteger();
 
         final Runnable task = () -> {
-            if (couponService.isUnavailableCoupon(TEST_COUPON_CODE)) {
-                failCount.incrementAndGet();
-            } else {
+            try {
+                couponService.tryConsumeIfPresent(TEST_COUPON_CODE);
                 successCount.incrementAndGet();
+            } catch (final CouponException e) {
+                failCount.incrementAndGet();
             }
             latch.countDown();
         };

--- a/src/test/java/site/brainbrain/iqtest/service/EmailServiceTest.java
+++ b/src/test/java/site/brainbrain/iqtest/service/EmailServiceTest.java
@@ -50,7 +50,7 @@ class EmailServiceTest {
         pdf.write("test certificate".getBytes(StandardCharsets.UTF_8));
 
         // when
-        emailService.send(email, name, pdf);
+        emailService.sendCertificate(email, name, pdf);
 
         // then
         assertThat(greenMail.waitForIncomingEmail(5000, 1)).isTrue();
@@ -74,7 +74,7 @@ class EmailServiceTest {
         final ByteArrayOutputStream pdf = new ByteArrayOutputStream();
 
         // when & then
-        assertThatThrownBy(() -> failEmailService.send("test@example.com", "tester", pdf))
+        assertThatThrownBy(() -> failEmailService.sendCertificate("test@example.com", "tester", pdf))
                 .isInstanceOf(BrainBrainMailException.class)
                 .hasMessageContaining("이메일 전송에 실패했습니다.");
     }


### PR DESCRIPTION
쿠폰 사용 시점을 결제 쪽으로 변경했습니다.

결과 생성 로직을 전략패턴 사용하도록 변경했습니다.
지금 BASIC 옵션 선택 시 메일 본문에 점수만 보내주는데 간단한 이미지라도 만들어서 보내주는게 좋을지 고민해보면 좋겠습니다.

폰트와 인증서 템플릿 이미지 gitignore에 추가했습니다

