### PR TITLE
결제 취소 전 결제 상태 조회 추가

### DIFF
--- a/src/main/java/site/brainbrain/iqtest/controller/PaymentController.java
+++ b/src/main/java/site/brainbrain/iqtest/controller/PaymentController.java
@@ -30,10 +30,13 @@ public class PaymentController {
     public ResponseEntity<PaymentConfirmResponse> confirm(@RequestParam(name = "coupon", required = false) final String coupon,
                                                           @RequestParam final Map<String, String> params) {
         couponService.tryConsumeIfPresent(coupon);
-
-        final PaymentConfirmResponse response = paymentService.pay(params);
-        return ResponseEntity.status(HttpStatus.FOUND)
-                .location(URI.create("https://brainbrain.site/")) // 임시 리다이렉트 경로
-                .body(response);
+        try {
+            final PaymentConfirmResponse response = paymentService.pay(params);
+            return ResponseEntity.status(HttpStatus.FOUND)
+                    .location(URI.create("https://brainbrain.site/payments/success"))
+                    .body(response);
+        } catch (final Exception e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).build(); // 결제 실패 테스트 임시 응답
+        }
     }
 }

--- a/src/main/java/site/brainbrain/iqtest/exception/PaymentFailAndCancelledException.java
+++ b/src/main/java/site/brainbrain/iqtest/exception/PaymentFailAndCancelledException.java
@@ -1,0 +1,8 @@
+package site.brainbrain.iqtest.exception;
+
+public class PaymentFailAndCancelledException extends RuntimeException {
+
+    public PaymentFailAndCancelledException(String message) {
+        super(message);
+    }
+}


### PR DESCRIPTION
결제를 취소하기 전, 결제 상태를 조회하는 요청을 보내 status 가 "paid" 일 경우만 취소합니다
응답은 아직 예외처리를 구현하지 않아 컨트롤러에서 임시로 응답 분기 나눕니다

프론트랑 연동 테스트중으로 리뷰 없이 머지할게요