### PR TITLE
pdf 리소스 로딩 방식 수정

### DIFF
--- a/src/main/java/site/brainbrain/iqtest/service/CertificateService.java
+++ b/src/main/java/site/brainbrain/iqtest/service/CertificateService.java
@@ -28,8 +28,8 @@ public class CertificateService {
         try {
             ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
 
-            String path = new ClassPathResource("/static/certification.pdf").getFile().getAbsolutePath();
-            PDDocument doc = PDDocument.load(new File(path));
+            InputStream pdfStream = new ClassPathResource("static/certification.pdf").getInputStream();
+            PDDocument doc = PDDocument.load(pdfStream);
             writeDateAndCertificateNo(doc);
             writeName(doc, name);
             writeScore(doc, score.cattell());


### PR DESCRIPTION
JAR 내부의 리소스는 파일 시스템에 존재하지 않아 기존에 사용하던 ClassPathResource.getFile() 방식으로는 static/certification.pdf 파일을 불러올 수 없어 FileNotFoundException이 발생했습니다.
InputStream 방식으로 변경했습니다
